### PR TITLE
Also set $wgCanonicalServer, otherwise, mediawiki can't generate correct canonical URLs

### DIFF
--- a/nubis/cloudformation/main.json
+++ b/nubis/cloudformation/main.json
@@ -279,6 +279,24 @@
         ]
       }
     },
+    "wgCanonicalServer": {
+      "Description": "Consul: config/ Server url",
+      "Value": {
+        "Fn::Join": [
+          ".",
+          [
+            "https://www",
+            {
+              "Ref": "ServiceName"
+            },
+            {
+              "Ref": "Environment"
+            },
+            "nubis.allizom.org"
+          ]
+        ]
+      }
+    },
     "wgDBserver": {
       "Description": "Consul: config/ Database endpoint",
       "Value": {


### PR DESCRIPTION
See: http://www.mediawiki.org/wiki/Manual:$wgCanonicalServer
